### PR TITLE
Feat/refactor

### DIFF
--- a/.github/scripts/job_filtering.py
+++ b/.github/scripts/job_filtering.py
@@ -5,6 +5,7 @@ Handles category-based filtering for different use cases (DM alerts vs digest).
 """
 
 from state_utils import should_include_item
+from github_helper import debug_log
 
 # Category filtering: Only allow these categories for DM alerts (strict filtering)
 ALLOWED_CATEGORIES_DM = {
@@ -53,6 +54,7 @@ def classify_job_category(job):
         
         # Category exists but not mappable - fall back to title classification
         # This handles cases where SimplifyJobs adds new categories
+        debug_log(f"[CATEGORY-UNMAPPED] Unknown category '{category}' for job: {job.get('company_name', 'Unknown')} - {job.get('title', 'Unknown')[:50]}... | Falling back to title classification")
     
     # Fallback: classify by title if no category exists or category not mappable
     title = job.get("title", "").lower()

--- a/.github/scripts/job_filtering.py
+++ b/.github/scripts/job_filtering.py
@@ -12,6 +12,17 @@ ALLOWED_CATEGORIES_DM = {
     "Data Science, AI & Machine Learning"
 }
 
+# SimplifyJobs actual category labels → canonical mapping for DM filtering
+SIMPLIFY_CATEGORY_MAPPING = {
+    "Software": "Software Engineering",
+    "AI/ML/Data": "Data Science, AI & Machine Learning", 
+    "Data Science": "Data Science, AI & Machine Learning",
+    "Machine Learning": "Data Science, AI & Machine Learning",
+    "AI": "Data Science, AI & Machine Learning",
+    "Software Engineering": "Software Engineering",  # Already canonical
+    "Data Science, AI & Machine Learning": "Data Science, AI & Machine Learning"  # Already canonical
+}
+
 # Category filtering for digest: allow several categories, exclude "Other"
 ALLOWED_CATEGORIES_DIGEST = {
     "Software Engineering",
@@ -30,12 +41,20 @@ def classify_job_category(job):
     # First check if there's an existing category field (SimplifyJobs has this)
     if "category" in job and job["category"]:
         category = job["category"].strip()
+        
+        # Map SimplifyJobs actual labels to canonical categories
+        canonical_category = SIMPLIFY_CATEGORY_MAPPING.get(category)
+        if canonical_category:
+            return canonical_category
+            
+        # Check if it's already in canonical form
         if category in ALLOWED_CATEGORIES_DM:
             return category
-        # If existing category is not in allowed list, filter out
-        return None
+        
+        # Category exists but not mappable - fall back to title classification
+        # This handles cases where SimplifyJobs adds new categories
     
-    # Fallback: classify by title if no category exists
+    # Fallback: classify by title if no category exists or category not mappable
     title = job.get("title", "").lower()
     
     # Data Science & AI & Machine Learning (first priority for overlapping terms)

--- a/.github/scripts/state_utils.py
+++ b/.github/scripts/state_utils.py
@@ -6,6 +6,7 @@ Provides utilities to track when job listings were last alerted and allow
 re-opened roles (updated date_updated) to alert again immediately.
 """
 import json
+import os
 import pathlib
 import time
 from datetime import datetime, timezone
@@ -13,6 +14,20 @@ from urllib.parse import urlparse
 
 # Reopen detection grace period - prevents identical re-additions from bypassing TTL
 REOPEN_GRACE_PERIOD = 3600  # 1 hour in seconds
+
+# Per-repo grace period overrides (environment variable fallbacks)
+def get_repo_grace_period(repo_name):
+    """Get grace period for specific repo, with env var overrides"""
+    if not repo_name:
+        return REOPEN_GRACE_PERIOD
+    
+    repo_lower = repo_name.lower()
+    if "simplify" in repo_lower:
+        return int(os.getenv("SIMPLIFY_REOPEN_GRACE_SECONDS", REOPEN_GRACE_PERIOD))
+    elif "vansh" in repo_lower:
+        return int(os.getenv("VANSH_REOPEN_GRACE_SECONDS", REOPEN_GRACE_PERIOD))
+    else:
+        return REOPEN_GRACE_PERIOD
 
 def get_primary_url(item):
     """Return the canonical URL for a listing (url or application_link)."""
@@ -140,7 +155,7 @@ def save_seen(seen, ttl_days, path=".state/seen.json", max_entries=200000):
     except Exception as e:
         print(f"Warning: Failed to save seen cache to {path}: {e}")
 
-def should_alert_item(item, seen, ttl_seconds, now_epoch):
+def should_alert_item(item, seen, ttl_seconds, now_epoch, repo_override=None):
     """
     Determine if an item should trigger an alert based on seen cache and TTL.
     
@@ -149,6 +164,7 @@ def should_alert_item(item, seen, ttl_seconds, now_epoch):
         seen: dict[str, int] seen cache
         ttl_seconds: int, TTL in seconds
         now_epoch: int, current time as epoch seconds
+        repo_override: Optional repo name for per-repo grace period (e.g., "SimplifyJobs/repo")
     
     Returns:
         tuple[bool, str]: (should_alert, reason)
@@ -167,9 +183,12 @@ def should_alert_item(item, seen, ttl_seconds, now_epoch):
     # Check if job was re-opened (updated after last alert) with grace period
     updated_epoch = parse_epoch(item.get("date_updated")) or parse_epoch(item.get("date_posted"))
     if updated_epoch is not None and updated_epoch > last_alert:
-        # Grace period: only treat as reopen if update is at least 1 hour after last alert
-        # This prevents identical re-additions with bumped timestamps from bypassing TTL
-        if updated_epoch - last_alert >= REOPEN_GRACE_PERIOD:
+        # Get per-repo grace period if repo is provided
+        grace_period = get_repo_grace_period(repo_override) if repo_override else REOPEN_GRACE_PERIOD
+        
+        # Grace period: only treat as reopen if enough time has passed since last alert
+        # This prevents spam re-alerts for minor updates but allows genuine reopens after grace period
+        if now_epoch - last_alert >= grace_period:
             return True, "reopen"
         # Within grace period - fall through to TTL check
     

--- a/.github/scripts/state_utils.py
+++ b/.github/scripts/state_utils.py
@@ -11,6 +11,9 @@ import time
 from datetime import datetime, timezone
 from urllib.parse import urlparse
 
+# Reopen detection grace period - prevents identical re-additions from bypassing TTL
+REOPEN_GRACE_PERIOD = 3600  # 1 hour in seconds
+
 def get_primary_url(item):
     """Return the canonical URL for a listing (url or application_link)."""
     return (item.get("url") or item.get("application_link") or "").strip()
@@ -161,24 +164,20 @@ def should_alert_item(item, seen, ttl_seconds, now_epoch):
     if last_alert is None:
         return True, "new"
     
-    # Check if TTL has expired
-    if now_epoch - last_alert > ttl_seconds:
-        return True, "ttl_expired"
-    
-    # Check if job was re-opened (updated after last alert)
-    # Add grace period to prevent identical re-additions from bypassing TTL
+    # Check if job was re-opened (updated after last alert) with grace period
     updated_epoch = parse_epoch(item.get("date_updated")) or parse_epoch(item.get("date_posted"))
     if updated_epoch is not None and updated_epoch > last_alert:
         # Grace period: only treat as reopen if update is at least 1 hour after last alert
         # This prevents identical re-additions with bumped timestamps from bypassing TTL
-        REOPEN_GRACE_PERIOD = 3600  # 1 hour in seconds
         if updated_epoch - last_alert >= REOPEN_GRACE_PERIOD:
             return True, "reopen"
-        # Within grace period - treat as potential duplicate, apply TTL check
-        if now_epoch - last_alert > ttl_seconds:
-            return True, "ttl_expired_after_grace"
+        # Within grace period - fall through to TTL check
     
-    # Suppress: within TTL and no recent update
+    # Check if TTL has expired (covers both normal TTL and post-grace-period cases)
+    if now_epoch - last_alert > ttl_seconds:
+        return True, "ttl_expired"
+    
+    # Suppress: within TTL and no recent update (or update within grace period)
     return False, "suppressed"
 
 def format_epoch_for_log(epoch):

--- a/.github/scripts/watch_repo.py
+++ b/.github/scripts/watch_repo.py
@@ -214,9 +214,9 @@ def main():
                     company = item.get("company_name", "Unknown")
                     title = item.get("title", "Unknown")
                     debug_log(f"ALLOW-REOPEN {company} - {title} | URL={url[:50]}... | updated_epoch={updated_epoch} ({format_epoch_for_log(updated_epoch)})")
-                elif reason in ["ttl_expired", "ttl_expired_after_grace"]:
+                elif reason in ["ttl_expired"]:
                     last_alert = seen.get(cache_key)
-                    debug_log(f"ALLOW-TTL key={cache_key} last={format_epoch_for_log(last_alert)} ttl={SEEN_TTL_DAYS}d reason={reason}")
+                    debug_log(f"ALLOW-TTL key={cache_key} last={format_epoch_for_log(last_alert)} ttl={SEEN_TTL_DAYS}d")
                 elif reason == "new":
                     debug_log(f"ALLOW-NEW key={cache_key}")
             else:

--- a/.github/scripts/watch_repo.py
+++ b/.github/scripts/watch_repo.py
@@ -207,13 +207,18 @@ def main():
                 final_entries.append(entry)
                 cache_key = get_cache_key(entry["item"])
                 if reason == "reopen":
-                    # Enhanced logging for reopen events
+                    # Enhanced logging for reopen events with telemetry
                     item = entry["item"]
                     url = get_primary_url(item)
                     updated_epoch = parse_epoch(item.get("date_updated")) or parse_epoch(item.get("date_posted"))
                     company = item.get("company_name", "Unknown")
                     title = item.get("title", "Unknown")
-                    debug_log(f"ALLOW-REOPEN {company} - {title} | URL={url[:50]}... | updated_epoch={updated_epoch} ({format_epoch_for_log(updated_epoch)})")
+                    last_alert = seen.get(cache_key)
+                    
+                    # Telemetry: delta = time between update and last alert, elapsed = time since last alert
+                    delta = updated_epoch - last_alert if updated_epoch and last_alert else 0
+                    elapsed = now_epoch - last_alert if last_alert else 0
+                    debug_log(f"ALLOW-REOPEN {company} - {title} | URL={(url or '')[:50]}... | delta={delta}s elapsed={elapsed}s | updated_epoch={updated_epoch} ({format_epoch_for_log(updated_epoch)})")
                 elif reason in ["ttl_expired"]:
                     last_alert = seen.get(cache_key)
                     debug_log(f"ALLOW-TTL key={cache_key} last={format_epoch_for_log(last_alert)} ttl={SEEN_TTL_DAYS}d")

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Environment variables in workflows:
 - **Save strategy**: Always save a new cache at the end of a run (immutable), then prune old caches with a cleanup workflow (below).
 - For TTL details, see `docs/TTL_IMPLEMENTATION.md`.
 
+Note on reopen/grace window: the watcher uses a short "reopen" grace window (default 1 hour) when deciding whether a previously alerted listing that shows a newer `date_updated` should re-alert. Minor timestamp bumps or metadata-only tweaks within this grace window are suppressed to avoid duplicate alerts; larger updates after the grace period are treated as reopens and will notify again. This behavior is controlled by the `REOPEN_GRACE_PERIOD` constant in the code and can be tuned if needed.
+
 ## Workflows
 
 ### DM Fast Watch (`.github/workflows/dm-fast-watch.yml`)


### PR DESCRIPTION
Summary
This PR introduces several improvements and bug fixes to the job tracker bot, focusing on notification quality, duplicate alert suppression, and documentation clarity. The changes address issues in both the channel digest and DM alert workflows, ensuring more reliable and relevant notifications.

Reopen Grace Period: Added a 1-hour grace window (REOPEN_GRACE_PERIOD) to suppress duplicate DM alerts for minor listing updates, only re-alerting for substantial changes after the grace period.
SimplifyJobs Category Mapping: Mapped SimplifyJobs categories to canonical DM categories, with a fallback to title-based classification, ensuring valid listings are not incorrectly filtered out.
Enhanced Logging: Improved logging for reopen events, including company, title, URL, and update timestamps for easier debugging.
Documentation Update: Added a note to the README explaining the TTL grace window and its role in duplicate alert suppression.